### PR TITLE
fix no backend error in login

### DIFF
--- a/src/pages/Login/data.tsx
+++ b/src/pages/Login/data.tsx
@@ -27,12 +27,15 @@ export class LoginEvent implements WatchEvent {
       }),
       catchError((error) => {
         console.log("error: ", error.message);
-        if(error.response.error.details) {
+
+        if(error?.response?.error?.details != null) {
           alertService.error(error.response.error.details[0].message);
+        } else if (error?.response?.error?.message) {
+            alertService.error(error?.response?.error?.message);
         } else {
-          alertService.error(error.response.error.message);
+          alertService.error("no backend response : " + error);
         }
-        return of(error);
+        return of(error.message );
       }),
     )
   }


### PR DESCRIPTION
I wonder if we should and an alert system when the backend gives no response at all. Here I added an alert example in the Login page but maybe we should add a global alert system, in the index, that shows NO API RESPONSE message when the front is started so people remember to check the backend.  Any ideas?